### PR TITLE
Limite de descripcion de libros añadido

### DIFF
--- a/src/main/java/es/codeurjc/ais/book/BookDetail.java
+++ b/src/main/java/es/codeurjc/ais/book/BookDetail.java
@@ -7,6 +7,8 @@ import es.codeurjc.ais.review.Review;
 
 public class BookDetail extends Book{
 
+    private final int MAX_BOOK_DESCRIPTION_LENGTH = 950;
+
     private String description;
 
     private String imageUrl;
@@ -16,7 +18,7 @@ public class BookDetail extends Book{
     private List<Review> reviews = new ArrayList<>();
 
     public String getDescription() {
-        return description;
+        return checkBookDescriptionLength();
     }
 
     public void setDescription(String description) {
@@ -33,7 +35,7 @@ public class BookDetail extends Book{
 
     @Override
     public String toString() {
-        return "BookDetail [description=" + description + ", imageUrl=" + imageUrl + "]";
+        return "BookDetail [description=" + checkBookDescriptionLength() + ", imageUrl=" + imageUrl + "]";
     }
 
     public List<Review> getReviews() {
@@ -50,5 +52,16 @@ public class BookDetail extends Book{
 
     public void setSubjects(String[] subjects) {
         this.subjects = subjects;
+    }
+
+    private String checkBookDescriptionLength() {
+        if (description.length() > MAX_BOOK_DESCRIPTION_LENGTH) {
+            String descriptionShorted = description.substring(0, MAX_BOOK_DESCRIPTION_LENGTH-1);
+            descriptionShorted += "...";
+            return descriptionShorted;
+        }
+        else {
+            return description;
+        }
     }
 }


### PR DESCRIPTION
Se ha añadido un límite en la longitud de la descripción de un libro, de 950 caracteres. En caso de superar este limite, se añaden tres puntos (…) a continuación del carácter 950.